### PR TITLE
fix: skip go test when directory is e2e

### DIFF
--- a/.github/workflows/go-basic-tests.yaml
+++ b/.github/workflows/go-basic-tests.yaml
@@ -86,11 +86,11 @@ jobs:
 
       - name: Test race conditions
         if: ${{ env.CGO_ENABLED == 1 }}
-        run: go test -v -race ${{ inputs.UNIT_TESTS_PATH }}
+        run: go test -v -race $(go list ${{ inputs.UNIT_TESTS_PATH }} | grep -v /e2e)
 
       - name: Test without race conditions
         if: ${{ env.CGO_ENABLED != 1 }}
-        run: go test -v ${{ inputs.UNIT_TESTS_PATH }}
+        run: go test -v $(go list ${{ inputs.UNIT_TESTS_PATH }} | grep -v /e2e)
         
       - name: Initialize CodeQL
         continue-on-error: true
@@ -167,7 +167,7 @@ jobs:
       
     - name: Test coverage
       id: unit-test
-      run: go test -v ${{ inputs.UNIT_TESTS_PATH }} -covermode=count -coverprofile=coverage.out
+      run: go test -v $(go list ${{ inputs.UNIT_TESTS_PATH }} | grep -v /e2e) -covermode=count -coverprofile=coverage.out
 
     - name: Convert coverage count to lcov format
       uses: jandelgado/gcov2lcov-action@v1


### PR DESCRIPTION
This PR allows us to skip certain directories where unit tests are not needed.
In [this](https://github.com/kubescape/host-scanner/actions/runs/5080350528/jobs/9127199993?pr=44#step:5:104) example `go-basic-tests.yaml` run `go test -v ./...` over the whole repository.
This is not necessary, since `e2e/` tests are already covered by ginkgo in a different pipeline.
Additionally, `go-basic-tests.yaml` fails because `e2e/` directory is not tested with the necessary tags (`-tags kind`, `-tags aks`,..).