### PR TITLE
feat: add possibility to use different branch for system-tests

### DIFF
--- a/.github/workflows/sanity-check.yaml
+++ b/.github/workflows/sanity-check.yaml
@@ -8,6 +8,9 @@ on:
  
   workflow_call:
       inputs:
+        SYSTEM_TESTS_BRANCH:
+          type: string
+          default: "master"
         BINARY_TESTS:
           type: string
           default: '[ "scan_nsa", 
@@ -67,6 +70,7 @@ jobs:
           with:
             repository: armosec/system-tests
             path: .
+            ref: ${{ inputs.SYSTEM_TESTS_BRANCH }}
 
         - uses: actions/setup-python@v4
           with:

--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ The Helm chart CICD will:
 
 ### A draw of the flow:
 ![Workflow](./assets/incluster_component_flow.jpeg)
+
+## Available Workflows
+
+Here's the list of reusable workflows available from this repository:
+
+| **Name**            | **Variables**                                                | **Description**                                              |
+| ------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `sanity-check.yaml` | -  `SYSTEM_TESTS_BRANCH`: define alternative branch to clone for [system-tests](github.com/armosec/system-tests) repository. Default: `master`<br />- `BINARY_TESTS`: specify which tests are going to be executed by the workflow. | This workflow allow you to run **system-tests** in the **production** environment |


### PR DESCRIPTION
This PR introduces a new variable on the `sanity-check.yaml` workflow to manage different branches of the system-tests repository.