### PR TITLE
pass component prerelease image tag to E2E tests

### DIFF
--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -286,8 +286,8 @@ jobs:
                     -f "client_payload[systests_branch]=${{ inputs.SYSTEM_TESTS_BRANCH }}" \
                     -f "client_payload[in_cluster_chart_branch]=${{ inputs.HELM_BRANCH }}" \
                     -f "client_payload[ks_branch]=release" \
-                    -f "client_payload[charts_name]=kubescape-operator" \
-                    -f "client_payload[charts_repo]=kubescape/helm-charts"
+                    -f "client_payload[charts_repo]=kubescape/helm-charts" \
+                    -f "client_payload[component_image_tags]=${{ inputs.COMPONENT_NAME }}-tag=${{ needs.docker-build.outputs.IMAGE_TAG_PRERELEASE }}"
 
                   echo "Dispatch completed"
 


### PR DESCRIPTION
## Summary
- Pass the prerelease image tag via `component_image_tags` in the E2E dispatch payload so system tests run against the actual built image instead of the default release
- Removes `charts_name` from the dispatch (receiver already defaults it to `kubescape-operator`) to stay within GitHub's 10 top-level key limit on `client_payload`
- Companion PRs: armosec/shared-workflows (forward `COMPONENT_IMAGE_TAGS` in receiver) and kubescape/node-agent (same change in its local workflow copy)

## How it works
The dispatch now includes `component_image_tags=<component>-tag=<prerelease-version>` (e.g., `operator-tag=v0.2.42-prerelease`). The receiver forwards it to `b-run-system-tests-self-hosted.yaml` which already supports `COMPONENT_IMAGE_TAGS` and appends it to `--kwargs` for `systest-cli.py`.

## Test plan
- [ ] Merge armosec/shared-workflows companion PR first (receiver must forward the new field)
- [ ] Trigger a component PR merge and verify the dispatch includes `component_image_tags`
- [ ] Verify system tests install the helm chart with the prerelease image override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow for dispatching system tests: the dispatched payload now includes component image tag information and removes an obsolete payload field, with payload ordering adjusted. This refines how test runs are triggered without changing test groups or target branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->