### PR TITLE
feat: add container image provenance attestation to shared workflow

### DIFF
--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -128,6 +128,7 @@ jobs:
             packages: write
             contents: read
             pull-requests: read
+            attestations: write
 
         steps:
             # - name: Exit if not on master branch
@@ -167,6 +168,7 @@ jobs:
                   password: ${{ secrets.QUAYIO_REGISTRY_PASSWORD }}
 
             - name: Build and push
+              id: build
               uses: docker/build-push-action@v6
               with:
                   context: .
@@ -177,6 +179,13 @@ jobs:
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
                   push: true
+
+            - name: Attest image provenance
+              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+              with:
+                  subject-name: ${{ inputs.IMAGE_NAME }}
+                  subject-digest: ${{ steps.build.outputs.digest }}
+                  push-to-registry: true
 
             - name: Install cosign
               uses: sigstore/cosign-installer@main

--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -183,7 +183,7 @@ jobs:
             - name: Attest image provenance
               uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
               with:
-                  subject-name: ${{ inputs.IMAGE_NAME }}:${{ steps.image-prerelease-tag.outputs.IMAGE_TAG_PRERELEASE }}
+                  subject-name: ${{ inputs.IMAGE_NAME }}
                   subject-digest: ${{ steps.build.outputs.digest }}
                   push-to-registry: true
 

--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -181,7 +181,7 @@ jobs:
                   push: true
 
             - name: Attest image provenance
-              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+              uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
               with:
                   subject-name: ${{ inputs.IMAGE_NAME }}
                   subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -183,7 +183,7 @@ jobs:
             - name: Attest image provenance
               uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
               with:
-                  subject-name: ${{ inputs.IMAGE_NAME }}
+                  subject-name: ${{ inputs.IMAGE_NAME }}:${{ steps.image-prerelease-tag.outputs.IMAGE_TAG_PRERELEASE }}
                   subject-digest: ${{ steps.build.outputs.digest }}
                   push-to-registry: true
 


### PR DESCRIPTION
## Overview

Adds `actions/attest-build-provenance` to the shared `incluster-comp-pr-merged.yaml` workflow so all components using it get SLSA provenance attestation on every release. This is the follow-up to kubescape/kubescape#2346 which added binary attestation to the CLI release workflow.

Components covered by this single change:
- operator
- kubevuln
- storage
- node-agent
- synchronizer
- http-request
- prometheus-exporter

The image digest is captured from the `build-push` step and attested using `subject-digest` for accurate per-digest attestation. The attestation is pushed to the registry alongside the image.

Users can verify any released image with:

```bash
gh attestation verify --owner kubescape oci://quay.io/kubescape/<component>:<tag>
```

## Additional Information

Also adds `attestations: write` permission to the `docker-build` job as required by the action.

## Related issues/PRs

* Part of #1033 (kubescape/kubescape)
* Follow-up to kubescape/kubescape#2346

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI Docker build/push now publishes image provenance attestations to the registry, tying attestations to the built image and enabling registry-side verification before signing. Permissions and workflow steps were updated to support attestation publishing, improving artifact verification and supply-chain security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->